### PR TITLE
Fix misalignment of image and description text

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -69,3 +69,9 @@ of those sections to manage the look and feel of the site. */
     padding-top: 40px;
     padding-bottom: 20px;
 }
+
+.img-responsive {
+    /* This really should just be part of bootstrap,
+       hence the globally applied style. */
+    margin: auto;
+}

--- a/index.html
+++ b/index.html
@@ -90,17 +90,18 @@
     <!-- about me  -->
     <section id="about me" class="first-section">
         <div class="container">
+            <div class="row">
+                <div class="col-xs-12">
+                    <h1>about me</h1>
+                </div>
+            </div>
             <div class="item row">
                 <div class="col-md-2 col-sm-10 col-xs-12">
-                    <h1> about me </h1>
                     <img class="img-responsive" src="jovo.png"/>
                 </div>
-
                 <div class="desc col-md-10 col-sm-10 col-xs-12">
-                   <h1 style="opacity: 0">me</h1>
-                   <!-- ^ you better look at this comment jovo because this css hack makes it line up -->
-                   <p> 
-                    I am an Assistant Professor in the Department of <a href="http://www.bme.jhu.edu/">Biomedical Engineering</a> and the <a href="http://www.icm.jhu.edu/">Institute for Computational Medicine</a> at <a href="https://www.jhu.edu/">Johns Hopkins University</a>.  I sit at the <a href="http://cis.jhu.edu/">Center for Imaging Science</a> in Clark Hall at the Homewood campus.  I also have an appointment in the <a href="http://idies.jhu.edu/">Institute for Data Intensive Engineering and Sciences</a>.  My work focuses largely on big and wide data, especially neuroscience, focusing on statistics of brain graphs (connectomes).  I co-founded the <a href="http://ocp.me">Open Connectome Project</a> with my brother R. Jacob Vogelstein and <a href="http://hssl.cs.jhu.edu/~randal/">Randal Burns</a>, Associated Professor in the Department of Computer Science at Johns Hopkins University.  We run a very vertical group, with people working at all levels of analysis, ranging from data collection to analysis and interpretation.  We are always looking for new collaborators and team members.  Please <a href="mailto:jovo@jhu.edu">inquire</a> if you are interested. 
+                    <p>
+                        I am an Assistant Professor in the Department of <a href="http://www.bme.jhu.edu/">Biomedical Engineering</a> and the <a href="http://www.icm.jhu.edu/">Institute for Computational Medicine</a> at <a href="https://www.jhu.edu/">Johns Hopkins University</a>.  I sit at the <a href="http://cis.jhu.edu/">Center for Imaging Science</a> in Clark Hall at the Homewood campus.  I also have an appointment in the <a href="http://idies.jhu.edu/">Institute for Data Intensive Engineering and Sciences</a>.  My work focuses largely on big and wide data, especially neuroscience, focusing on statistics of brain graphs (connectomes).  I co-founded the <a href="http://ocp.me">Open Connectome Project</a> with my brother R. Jacob Vogelstein and <a href="http://hssl.cs.jhu.edu/~randal/">Randal Burns</a>, Associated Professor in the Department of Computer Science at Johns Hopkins University.  We run a very vertical group, with people working at all levels of analysis, ranging from data collection to analysis and interpretation.  We are always looking for new collaborators and team members.  Please <a href="mailto:jovo@jhu.edu">inquire</a> if you are interested. 
                     </p>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -96,10 +96,10 @@
                 </div>
             </div>
             <div class="item row">
-                <div class="col-md-2 col-sm-10 col-xs-12">
+                <div class="col-md-2 col-sm-4 col-xs-12">
                     <img class="img-responsive" src="jovo.png"/>
                 </div>
-                <div class="desc col-md-10 col-sm-10 col-xs-12">
+                <div class="desc col-md-10 col-sm-8 col-xs-12">
                     <p>
                         I am an Assistant Professor in the Department of <a href="http://www.bme.jhu.edu/">Biomedical Engineering</a> and the <a href="http://www.icm.jhu.edu/">Institute for Computational Medicine</a> at <a href="https://www.jhu.edu/">Johns Hopkins University</a>.  I sit at the <a href="http://cis.jhu.edu/">Center for Imaging Science</a> in Clark Hall at the Homewood campus.  I also have an appointment in the <a href="http://idies.jhu.edu/">Institute for Data Intensive Engineering and Sciences</a>.  My work focuses largely on big and wide data, especially neuroscience, focusing on statistics of brain graphs (connectomes).  I co-founded the <a href="http://ocp.me">Open Connectome Project</a> with my brother R. Jacob Vogelstein and <a href="http://hssl.cs.jhu.edu/~randal/">Randal Burns</a>, Associated Professor in the Department of Computer Science at Johns Hopkins University.  We run a very vertical group, with people working at all levels of analysis, ranging from data collection to analysis and interpretation.  We are always looking for new collaborators and team members.  Please <a href="mailto:jovo@jhu.edu">inquire</a> if you are interested. 
                     </p>


### PR DESCRIPTION
...in the about-me section.

Bootstrap fills a `row` with `header`s at small screen sizes, hence the issue we saw with the old CSS hack.

Before:
![image](https://cloud.githubusercontent.com/assets/693511/7799925/24bdfa40-02db-11e5-8ea7-03398728c840.png)

After:
![image](https://cloud.githubusercontent.com/assets/693511/7799949/7ead5618-02db-11e5-8e61-99764343dd06.png)
